### PR TITLE
Better command line messages

### DIFF
--- a/engine/docker.go
+++ b/engine/docker.go
@@ -43,7 +43,7 @@ func (de DockerEngine) Name() string {
 }
 
 func (de DockerEngine) Title() string {
-	return "Docker Engine"
+	return "Commands for pulling images into Docker from Quay"
 }
 
 func (de DockerEngine) TorrentHandler() engineTorrentHandler {

--- a/engine/rkt.go
+++ b/engine/rkt.go
@@ -37,7 +37,7 @@ func (re RktEngine) Name() string {
 }
 
 func (re RktEngine) Title() string {
-	return "rkt"
+	return "Commands for pulling images into rkt from Quay"
 }
 
 func (re RktEngine) TorrentHandler() engineTorrentHandler {


### PR DESCRIPTION
```
Various utilities for working with the Quay container registry

Usage:
  quayctl
  quayctl [command]

Available Commands:
  rkt         Commands for pulling images into rkt from Quay
  docker      Commands for pulling images into Docker from Quay
  version     print the current version

Use "quayctl [command] --help" for more information about a command.
```
